### PR TITLE
test: check for LoginLink bug

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import {
   LoginLink,
   RegisterLink,
@@ -7,6 +8,7 @@ export default async function Home() {
   return (
     <main className="flex h-screen w-full flex-col items-center justify-center gap-4">
       <nav>
+        {env.NODE_ENV}
         <LoginLink postLoginRedirectURL="/auth-callback">Log In</LoginLink>
         <RegisterLink postLoginRedirectURL="/auth-callback">
           Register

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,11 +6,5 @@ export default function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    "/b/:businessID/:path*",
-    "/dashboard/:path*",
-    "/dashboard/:businessID/:path*",
-    "/new/:path*",
-    "/edit/:eventID/:path*",
-  ],
+  matcher: ["/dashboard/:path*"],
 };


### PR DESCRIPTION
LoginLink sets one of the authUrlParams (redirect_url) to localhost:3000 instead of Calendara.app – even in production deployments.