### PR TITLE
Weird Bug with Kinde Auth and the LoginLink Component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,6 @@ export default async function Home() {
   return (
     <main className="flex h-screen w-full flex-col items-center justify-center gap-4">
       <nav>
-        {env.NODE_ENV}
         <LoginLink postLoginRedirectURL="/auth-callback">Log In</LoginLink>
         <RegisterLink postLoginRedirectURL="/auth-callback">
           Register


### PR DESCRIPTION
Problem solved.

The error may be caused by some sort of caching? Maybe on the Vercel Env Variables or on the Browser.

A simple code push was enough to revert the error? Nothing changed, so the error may be a rare bug.